### PR TITLE
SCTVcode.ino - minor GPS timzone fix

### DIFF
--- a/SCTVcode/SCTVcode.ino
+++ b/SCTVcode/SCTVcode.ino
@@ -523,10 +523,12 @@ void getTheTime(void)
     // The minutes and hours may be out of range. Correct them if so
     if (Mins > 59)
     {
+      Mins -= 60;
       Hrs++;
     }
     if (Mins < 0)
     {
+      Mins += 60;
       Hrs--;
     }
     if (Hrs > 23) 


### PR DESCRIPTION
Logic to accommodate a timezone offset where the minutes were non-zero was incomplete when using GPS time.
If Minutes + Timezone_Minutes > 59  or < 0, the hour was adjusted correctly however Minutes were left unadjusted.
This minor fix should increment or decrement the minutes appropriately.