### PR TITLE
Store DST setting in DS3232 SRAM

### DIFF
--- a/SCTVcode/SCTVcode.ino
+++ b/SCTVcode/SCTVcode.ino
@@ -342,6 +342,7 @@ void writeRTClocale()
   Wire.write(ZMins);
   Wire.write(Hr12);
   Wire.write(Hertz);
+  Wire.write(DST);
   Wire.endTransmission();
 }
 
@@ -381,16 +382,18 @@ void readRTClocale()
   Wire.write(0x18);  // read locale data starting at byte 0x18
   Wire.endTransmission();
 
-  Wire.requestFrom(DS3232_ADDRESS, 6, 1);  // request seven bytes, then stop
+  Wire.requestFrom(DS3232_ADDRESS, 7, 1);  // request seven bytes, then stop
   if (Wire.read() == rtcMagic) {
     Century = Wire.read();
     Zone    = Wire.read() - 30;
     ZMins   = Wire.read();
     Hr12    = Wire.read();
     Hertz   = Wire.read();
+    DST     = Wire.read();
     rtcValid = 1;
   }
   else {
+    Wire.read();
     Wire.read();
     Wire.read();
     Wire.read();


### PR DESCRIPTION
Stores DST setting so it survives reboots of the tinyduino