### PR TITLE
Support for GPS on Serial2 port

### DIFF
--- a/SCTVcode/SCTVcode.ino
+++ b/SCTVcode/SCTVcode.ino
@@ -292,6 +292,10 @@ USBDriver *drivers[] = {&hub1, &hub2, &hid1, &hid2, &hid3, &userial};
 const char * driver_names[CNT_DEVICES] = {"Hub1", "Hub2",  "HID1", "HID2", "HID3", "USERIAL1" };
 bool driver_active[CNT_DEVICES] = {false, false, false, false, false, false};
 
+// --------------------------------- Serial2 port -----------------------------
+
+uint32_t serial2BaudRate = 9600;
+
 // ----------------------- DS3232 time keeping code ----------------------------------
 
 // Make day of week from date variables
@@ -420,12 +424,6 @@ static void readGPStime(TinyGPS &gps)
   byte mon, days, hr, mins, sec, hund;
   int yrs;
   
-  // bail if we don't have valid serial...
-  if (!userial) {
-     GPSage = TinyGPS::GPS_INVALID_AGE;
-    return;
-  }
-
   gps.crack_datetime(&yrs, &mon, &days, &hr, &mins, &sec, &hund, &GPSage);
   
   GPSHun  = hund; 
@@ -504,7 +502,7 @@ void getTheTime(void)
   readGPStime(myGps);   // get current time into time variables
 
   // See if the GPS time is good, use either it or the RTC accordingly
-  if ((GPSage == TinyGPS::GPS_INVALID_AGE) || (GPSage > 1000))     // not conencted or stale time
+  if ((GPSage == TinyGPS::GPS_INVALID_AGE) || (GPSage > 1500))     // not conencted or stale time
   {
     readRTCtime();   // get current time into time variables
   }

--- a/SCTVcode/z_main.ino
+++ b/SCTVcode/z_main.ino
@@ -19,6 +19,7 @@ void setup()
   rn1 = rn2 = rn3 = rn4 = 0x45;   // random number generator seed? Why not use random()?
   Wire.begin();          // RTC uses I2C
   Serial.begin(115200);    // debug port
+  Serial2.begin(serial2BaudRate); // Serial GPS port
   delay(100);
   EncDir = 0;    // no buttons being pushed or knobs being turned, we hope
   pushed = false;
@@ -123,6 +124,9 @@ void loop()
   if (userial) {
     while (userial.available())
       myGps.encode(userial.read());
+  } else {
+    while (Serial2.available())
+      myGps.encode(Serial2.read());
   }
 
   if ((theClock != 1) && (theClock != 2))  // Pong and Tetris use position controls as paddles


### PR DESCRIPTION
These changes add support for having a GPS receiver connected on the Serial2 port of the Teensy.

Some notes on the changes
- GPS connected on USB takes priority
- default baudrate is 9600 (I might look into autobauding later)
- GPS TX connected to pin 11 (GPIO9/RX2)
- GPS RX connected (optionally) to pin 12 (GPIO10/TX2)
- tested with BN180 GPS , in practice any NMEA GPS should work
- GPSage limit increased to 1500ms as with 1Hz update rate 1000ms can cause a glitching 